### PR TITLE
add github workflow: build and publish releases for linux, macos & windows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rasmus-saks/release-a-changelog-action@v1.0.1
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+  upload-assets:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: cksfv
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checksum: sha256
+          include: CHANGELOG.md,COPYING,README.md


### PR DESCRIPTION
This PR adds a Github action workflow, which will pick up future tags and automatically build and publish the releases on your Release tab. Please consider this PR.

My hope for this to be included is the following:

1. having pre-built binaries simplifies packaging and installation for the user
2. since this is a drop-in replacement for `cksfv`, this would be an easy path to get access to the tool for people on windows.
3. thanks to 2, i can then add package support for this to the [scoop package manager](https://scoop.sh/)


I tested the PR by creating some fake releases over here: https://github.com/martinlindhe/cksfv.rs/releases/tag/0.1.3